### PR TITLE
Polaris Provider v0.9.0-beta.3 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ No requirements.
 | [azuread_service_principal_password.polaris](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
 | [time_sleep.wait_for_sp](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [azuread_domains.polaris](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/domains) | data source |
+| [polaris_account.polaris](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/data-sources/account) | data source |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,17 @@ module "polaris-azure-cloud-native_tenant" {
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=0.9.0-beta.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.43.0 |
-| <a name="provider_polaris"></a> [polaris](#provider\_polaris) | 0.7.2 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | n/a |
+| <a name="provider_polaris"></a> [polaris](#provider\_polaris) | >=0.9.0-beta.3 |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ No requirements.
 | [azuread_application.polaris](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
 | [azuread_service_principal.polaris](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
 | [azuread_service_principal_password.polaris](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
-| [polaris_azure_service_principal.polaris](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/resources/azure_service_principal) | resource |
+| [time_sleep.wait_for_sp](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [azuread_domains.polaris](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/domains) | data source |
 
 ## Modules
@@ -56,6 +56,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_azure_tenant_id"></a> [azure\_tenant\_id](#input\_azure\_tenant\_id) | ID of Azure Tenant to protect. | `string` | n/a | yes |
 | <a name="input_polaris_credentials"></a> [polaris\_credentials](#input\_polaris\_credentials) | Full path to credentials file for RSC/Polaris. | `string` | n/a | yes |
+| <a name="input_rsc_sync_delay"></a> [rsc\_sync\_delay](#input\_rsc\_sync\_delay) | Delay so that Azure and RSC can sync on the new service principal. | `string` | `"60s"` | no |
 
 ## Outputs
 
@@ -178,4 +179,3 @@ We glady welcome contributions from the community. From updating the documentati
 ## Developers
 
 This [README.md](README.md) was created with [terraform-docs](https://github.com/terraform-docs/terraform-docs). To update any of the auto generated parameters between the `<!-- BEGIN_TF_DOCS -->` and `<!-- END_TF_DOCS -->` lines first modify the [.terraform-docs.yml](.terraform-docs.yml) file, if needed. Then run [gen_docs.sh](gen_docs.sh) in this modules directory. For any documentation that needs to be modified outside of the `<!-- BEGIN_TF_DOCS -->` and `<!-- END_TF_DOCS -->` lines, modify this [README.md](README.md) file directly.
-

--- a/README.md
+++ b/README.md
@@ -14,6 +14,29 @@ There are a few services you'll need in order to get this project off the ground
 ## Usage
 
 ```hcl
+
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+    }
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "0.9.0-beta.3"
+    } 
+  }
+}
+
+# Configure the Azure Active Directory Provider
+provider "azuread" {
+  tenant_id = var.azure_tenant_id
+}
+
+# Point the provider to the RSC service account to use.
+provider "polaris" {
+  credentials = var.polaris_credentials
+} 
+
 module "polaris-azure-cloud-native_tenant" {
   source                          = "rubrikinc/polaris-cloud-native_tenant/azure"
   
@@ -46,7 +69,9 @@ module "polaris-azure-cloud-native_tenant" {
 | [azuread_application.polaris](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
 | [azuread_service_principal.polaris](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
 | [azuread_service_principal_password.polaris](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
+| [polaris_azure_service_principal.polaris](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/resources/azure_service_principal) | resource |
 | [time_sleep.wait_for_sp](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 | [azuread_domains.polaris](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/domains) | data source |
 | [polaris_account.polaris](https://registry.terraform.io/providers/rubrikinc/polaris/latest/docs/data-sources/account) | data source |
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
-locals {
-  rsc_instance_fqdn = (element(split("/",jsondecode(file("${var.polaris_credentials}")).access_token_uri),2))
-}
+# Get RSC Account details
+data "polaris_account" "polaris" {}
 
 # get current user information
 data "azuread_client_config" "current" {}
@@ -16,7 +15,7 @@ resource "azuread_application" "polaris" {
   display_name = "Rubrik Cloud Integration - terraform"
   owners       = [data.azuread_client_config.current.object_id]
   web {
-    homepage_url  = "https://${local.rsc_instance_fqdn}/setup_azure"
+    homepage_url  = "https://${data.polaris_account.polaris.fqdn}/setup_azure"
   }
 }
 
@@ -44,4 +43,4 @@ resource "polaris_azure_service_principal" "polaris" {
 resource time_sleep "wait_for_sp" {
   depends_on      = [polaris_azure_service_principal.polaris]
   create_duration = var.rsc_sync_delay
-} 
+}

--- a/main.tf
+++ b/main.tf
@@ -39,3 +39,9 @@ resource "polaris_azure_service_principal" "polaris" {
   tenant_domain = data.azuread_domains.polaris.domains.0.domain_name
   tenant_id     = azuread_service_principal.polaris.application_tenant_id
 } 
+
+# Give RSC and   service principal to be created before adding the subscription.
+resource time_sleep "wait_for_sp" {
+  depends_on      = [polaris_azure_service_principal.polaris]
+  create_duration = var.rsc_sync_delay
+} 

--- a/providers.tf
+++ b/providers.tf
@@ -9,12 +9,12 @@ terraform {
   }
 }
 
-# Configure the Azure Active Directory Provider
-provider "azuread" {
-  tenant_id = var.azure_tenant_id
-}
+# # Configure the Azure Active Directory Provider
+# provider "azuread" {
+#   tenant_id = var.azure_tenant_id
+# }
 
-# Point the provider to the RSC service account to use.
-provider "polaris" {
-  credentials = var.polaris_credentials
-} 
+# # Point the provider to the RSC service account to use.
+# provider "polaris" {
+  #   credentials = var.polaris_credentials
+# } 

--- a/providers.tf
+++ b/providers.tf
@@ -5,6 +5,7 @@ terraform {
     }
     polaris = {
       source  = "rubrikinc/polaris"
+      version = ">=0.9.0-beta.3"
     } 
   }
 }
@@ -16,5 +17,5 @@ terraform {
 
 # # Point the provider to the RSC service account to use.
 # provider "polaris" {
-  #   credentials = var.polaris_credentials
+#   credentials = var.polaris_credentials
 # } 

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,8 @@ variable "polaris_credentials" {
   type        = string
   description = "Full path to credentials file for RSC/Polaris."
 }
+variable "rsc_sync_delay" {
+  type        = string
+  description = "Delay so that Azure and RSC can sync on the new service principal."
+  default     = "60s"  
+}


### PR DESCRIPTION
# Description

- [Added polaris provider version requirement.](https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_tenant/commit/9d14cfaf9004b3ce24e11d51be60f3cd0ba37a8b)
- [Switched to new polaris_account resource to get RSC FQDN](https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_tenant/commit/cca4bb24250aa51b730448935f77c7f205340dea)
- [Added delay to let RSC sync with Azure.](https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_tenant/commit/75c5972045db6ec8293c1aad6e504896767f3e59)

NOTE: There is a breaking change. The provider credentials have been moved outside of the module. They must now be specified before calling the module. See the updated README file for details. This was done so that the module could take sleep statements and be included in loops.

## Related Issue

None

## Motivation and Context

Updating to use the features of the new provider.

Added a timeout to keep Terraform from timing out or failing because RSC had not refreshed the tenant information.

## How Has This Been Tested?

Deployed a new tenant in RSC using this code.

## Screenshots (if appropriate):

None

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
