### PR TITLE
Use the display_name of the azuread_application resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,41 @@ module "polaris_azure_cloud_native_tenant" {
 ## Examples
 - [Basic Tenant](https://github.com/rubrikinc/terraform-azure-polaris-cloud-native_tenant/tree/master/examples/basic)
 
+## Changelog
+
+### v1.1.1
+  * Initialize the `app_name` of the `polaris_azure_service_principal` resource using the `display_name` of the
+    `azuread_application` instead of the `azuread_service_principal`.
+
+### v1.1.0
+  * Replace the `azuread_service_principal_password` resource with the `azuread_application_password` resource. This
+    will update the secret of the `polaris_azure_service_principal` resource.
+  * Add `azure_application_display_name` as an input variable.
+  * Mark `azure_tenant_id` and `polaris_credentials` input variables as deprecated. They are no longer used by the
+    module and have no replacements.
+  * Move example configuration code from the README.md file to the examples directory.
+
+## Upgrading
+
+### v1.0.1 to v1.1.x
+1. Change the version of the module from `1.0.1` to `1.1.1`. Depending on your configuration, you might need to update
+   the version of the [Cloud Native Tenant](https://registry.terraform.io/modules/rubrikinc/polaris-cloud-native_tenant/azure/latest)
+   module to version `2.1.0` for Terraform to be able to find a suitable version of the RSC (polaris) Terraform
+   provider.
+2. Run `terraform init -upgrade`. The `-upgrade` command line option is required since the updated module requires a new
+   version of the RSC (polaris) Terraform provider.
+3. Run `terraform plan`, this should result in an `Provider configuration not present` error. The resource
+   `module.azure_tenant.azuread_service_principal_password.polaris` should be orphaned. This is because the
+   `azuread_service_principal_password` resource has been replaced with an `azuread_application_password` resource.
+4. Run `terraform state rm module.azure_tenant.azuread_service_principal_password.polaris` to remove the orphaned
+   resource.
+5. Run `terraform plan` and check the output carefully, there should only be resources added or updated in place. There
+   should be no resources replaced or removed.
+6. Run `terraform apply`.
+
+Additional notes, the `azuread_application` resource haven been changed to require the `display_name` to be unique. If
+this causes any issue, you can change the display name using the new `azure_application_display_name` variable.
+
 ## Troubleshooting
 
 ### Error: failed to lookup principal

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ resource "azuread_application_password" "polaris" {
 # Add the service principal to RSC.
 resource "polaris_azure_service_principal" "polaris" {
   app_id        = azuread_application.polaris.client_id
-  app_name      = azuread_service_principal.polaris.display_name
+  app_name      = azuread_application.polaris.display_name
   app_secret    = azuread_application_password.polaris.value
   tenant_domain = data.azuread_domains.polaris.domains.0.domain_name
   tenant_id     = azuread_service_principal.polaris.application_tenant_id


### PR DESCRIPTION
# Description

Initialize the app_name of the polaris_azure_service_principal resource using the display_name of the azuread_application instead of the azuread_service_principal.

## Motivation and Context

Initializing the app_name from the azuread_service_principal resource confuses Terraform when the display name is changed using the azure_application_display_name variable since it changes the display name of the azuread_application and not the azuread_service_principal. The display name of the azuread_service_principal will be updated first after the new configuration has been applied.

## How Has This Been Tested?

Manually onboarded a new Azure tenant and subscription and updated the display name using the new azure_application_display_name variable.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
